### PR TITLE
refactor: replace prints with slf4j logging

### DIFF
--- a/src/main/java/com/wh/mcp_demo/config/ProxyConfig.java
+++ b/src/main/java/com/wh/mcp_demo/config/ProxyConfig.java
@@ -2,9 +2,12 @@ package com.wh.mcp_demo.config;
 
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Configuration
 public class ProxyConfig {
+    private static final Logger log = LoggerFactory.getLogger(ProxyConfig.class);
     private static final String PROXY_HOST = "127.0.0.1";
     private static final int PROXY_PORT = 10080;
 
@@ -16,7 +19,7 @@ public class ProxyConfig {
 //        System.setProperty("https.proxyHost", PROXY_HOST);
 //        System.setProperty("https.proxyPort", String.valueOf(PROXY_PORT));
 
-        System.out.println("System proxy configured: http://" + PROXY_HOST + ":" + PROXY_PORT);
+        log.info("System proxy configured: http://{}:{}", PROXY_HOST, PROXY_PORT);
 
 
     }

--- a/src/main/java/com/wh/mcp_demo/config/UsersDataInitializer.java
+++ b/src/main/java/com/wh/mcp_demo/config/UsersDataInitializer.java
@@ -5,6 +5,8 @@ import com.wh.mcp_demo.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -12,6 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UsersDataInitializer implements CommandLineRunner {
     private final UserRepository userRepository;
+    private static final Logger log = LoggerFactory.getLogger(UsersDataInitializer.class);
 
     @Override
     public void run(String... args) throws Exception {
@@ -47,8 +50,8 @@ public class UsersDataInitializer implements CommandLineRunner {
 
         userRepository.saveAll(List.of(u1, u2, u3, u4, u5, u6));
 
-        System.out.println("初始化數據完成");
+        log.info("初始化數據完成");
         List<User> all = userRepository.findAll();
-        all.forEach(System.out::println);
+        all.forEach(user -> log.info("{}", user));
     }
 }

--- a/src/main/java/com/wh/mcp_demo/controller/ChatController.java
+++ b/src/main/java/com/wh/mcp_demo/controller/ChatController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final ChatClient chatClient;
+    private static final Logger log = LoggerFactory.getLogger(ChatController.class);
 
     /**
      * 處理聊天，使用AI和MCP工具進行響應
@@ -30,13 +33,13 @@ public class ChatController {
                     .call()
                     .content();
 
-            System.out.println("查看回復content:" + content);
+            log.info("查看回復content:{}", content);
 
             ChatResponse build = ChatResponse.builder().content(content).build();
-            System.out.println(build);
+            log.info("{}", build);
             return ResponseEntity.ok(build);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("處理請求出錯", e);
             ChatResponse build = ChatResponse.builder().content("處理請求出錯" + e.getMessage()).build();
             return ResponseEntity.ok(build);
         }


### PR DESCRIPTION
## Summary
- use SLF4J logger in ProxyConfig
- swap System.out prints for info logs in UsersDataInitializer
- log chat responses and errors using SLF4J in ChatController

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5177301408327b2340bfeaef1bb9d